### PR TITLE
fix: italic style

### DIFF
--- a/src/guide/instance.md
+++ b/src/guide/instance.md
@@ -8,7 +8,7 @@
 Vue.createApp(/* 选项 */)
 ```
 
-创建实例后，我们可以_挂载_它，将容器传递给 `mount` 方法。例如，如果要在 `<div id="app"></div>` 上挂载 Vue 应用，则应传递 `#app`：
+创建实例后，我们可以*挂载*它，将容器传递给 `mount` 方法。例如，如果要在 `<div id="app"></div>` 上挂载 Vue 应用，则应传递 `#app`：
 
 ```js
 Vue.createApp(/* 选项 */).mount('#app')


### PR DESCRIPTION
很高兴终于有中文文档了！！！晚上看到一处斜体解析错误，英文版本是单词，下划线两端是空格，所以能正确解析。

依据[关于加粗和斜体格式的约定](https://github.com/vuejs/docs-next-zh-cn/wiki/%E6%9C%AF%E8%AF%AD%E7%BF%BB%E8%AF%91%E7%BA%A6%E5%AE%9A#%E5%85%B3%E4%BA%8E%E5%8A%A0%E7%B2%97%E5%92%8C%E6%96%9C%E4%BD%93%E6%A0%BC%E5%BC%8F%E7%9A%84%E7%BA%A6%E5%AE%9A)，修正为星号斜体。