### PR TITLE
fix: rename `tag` to `type`

### DIFF
--- a/src/api/global-api.md
+++ b/src/api/global-api.md
@@ -72,9 +72,9 @@ render() {
 
 ### 参数
 
-接收三个参数：`tag`，`props` 和 `children`
+接收三个参数：`type`，`props` 和 `children`
 
-#### tag
+#### type
 
 - **类型：**`String | Object | Function | null`
 


### PR DESCRIPTION
`h` 方法的第一个参数名称是`type`不再是`tag`。英文版PR已经merged : https://github.com/vuejs/docs-next/pull/450