### PR TITLE
fix: native searbox work when disabled algolia

### DIFF
--- a/src/.vuepress/theme/components/Navbar.vue
+++ b/src/.vuepress/theme/components/Navbar.vue
@@ -26,7 +26,7 @@
       <SearchBox
         v-if="
           isAlgoliaSearch === false &&
-            !(
+            (
               $site.themeConfig.search !== false &&
               $page.frontmatter.search !== false
             )
@@ -68,7 +68,7 @@ export default {
     },
 
     isAlgoliaSearch() {
-      return this.algolia && this.algolia.apiKey && this.algolia.indexName
+      return !!(this.algolia && this.algolia.apiKey && this.algolia.indexName)
     }
   },
 


### PR DESCRIPTION
- [fix: the isAlgoliaSearch variable set to boolean type](https://github.com/vuejs/docs-next/pull/519)
- 修复 native searchBox， 英文仓库已经merge，本次直接并入master