### PR TITLE
fix: change global-api provide

### DIFF
--- a/src/guide/migration/global-api.md
+++ b/src/guide/migration/global-api.md
@@ -162,15 +162,13 @@ app.mount('#app')
 
 ```js
 // 在入口
-app.provide({
-  guide: 'Vue 3 Guide'
-})
+app.provide('guide', 'Vue 3 Guide')
 
 // 在子组件
 export default {
   inject: {
     book: {
-      from: guide
+      from: 'guide'
     }
   },
   template: `<div>{{ book }}</div>`


### PR DESCRIPTION
修改全局api provide的代码用例，
保持和[https://github.com/vuejs/docs-next/blob/master/src/guide/migration/global-api.md#provide--inject](https://github.com/vuejs/docs-next/blob/master/src/guide/migration/global-api.md#provide--inject)一致

修复https://github.com/vuejs/docs-next-zh-cn/issues/106