### PR TITLE
fix: typos

### DIFF
--- a/src/guide/reactivity-fundamentals.md
+++ b/src/guide/reactivity-fundamentals.md
@@ -31,7 +31,7 @@ import { ref } from 'vue'
 const count = ref(0)
 ```
 
-`ref` 会返回一个可变的响应式对象，该对象作为它的内部值——一个**响应式的引用*，这就是名称的来源。此对象只包含一个名为 `value` 的 property` ：
+`ref` 会返回一个可变的响应式对象，该对象作为它的内部值——一个**响应式的引用**，这就是名称的来源。此对象只包含一个名为 `value` 的 property` ：
 
 ```js
 import { ref } from 'vue'
@@ -96,7 +96,6 @@ console.log(count.value) // 1
 
 Ref 展开仅发生在被响应式 `Object` 嵌套的时候。当从 `Array` 或原生集合类型如 [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)访问 ref 时，不会进行展开：
 
-
 ```js
 const books = reactive([ref('Vue 3 Guide')])
 // 这里需要 .value
@@ -106,7 +105,6 @@ const map = reactive(new Map([['count', ref(0)]]))
 // 这里需要 .value
 console.log(map.get('count').value)
 ```
-
 
 ## 响应式状态解构
 


### PR DESCRIPTION
docs-next-zh-cn/src/guide/reactivity-fundamentals.md 

该对象作为它的内部值——一个**响应式的引用** 

markdown 格式错误修复。