### PR TITLE
docs: update the `v-for v-if` priority

### DIFF
--- a/src/guide/conditional.md
+++ b/src/guide/conditional.md
@@ -91,4 +91,4 @@
 不推荐同时使用 `v-if` 和 `v-for`。请查阅[风格指南](../style-guide/#avoid-v-if-with-v-for-essential)以获取更多信息。
 :::
 
-当 `v-if` 与 `v-for` 一起使用时，`v-for` 具有比 `v-if` 更高的优先级。请查阅[列表渲染指南](list#v-for-with-v-if)以获取详细信息。
+当 `v-if` 与 `v-for` 一起使用时，`v-if` 具有比 `v-for` 更高的优先级。这意味着 `v-if` 将无法访问 `v-for` 范围内的变量。 `v-if` 请查阅[列表渲染指南](list#v-for-with-v-if)以获取详细信息。

--- a/src/guide/conditional.md
+++ b/src/guide/conditional.md
@@ -91,4 +91,4 @@
 不推荐同时使用 `v-if` 和 `v-for`。请查阅[风格指南](../style-guide/#avoid-v-if-with-v-for-essential)以获取更多信息。
 :::
 
-当 `v-if` 与 `v-for` 一起使用时，`v-if` 具有比 `v-for` 更高的优先级。这意味着 `v-if` 将无法访问 `v-for` 范围内的变量。 `v-if` 请查阅[列表渲染指南](list#v-for-with-v-if)以获取详细信息。
+当 `v-if` 与 `v-for` 一起使用时，`v-if` 具有比 `v-for` 更高的优先级。请查阅[列表渲染指南](list##v-for-与-v-if-一同使用)以获取详细信息。


### PR DESCRIPTION
## Description of Problem

阅读 英文文档 的 [列表渲染](https://v3.vuejs.org/guide/list.html#v-for-with-v-if) 发现 v-for 和 v-if 发生了重大变化，中文文档没有提及

> When they exist on the same node, v-if has a higher priority than v-for. That means the v-if condition will not have access to variables from the scope of the v-for

## Proposed Solution

按照原文进行修正

## Additional Information