### PR TITLE
docs: reword warning section

### DIFF
--- a/src/guide/component-template-refs.md
+++ b/src/guide/component-template-refs.md
@@ -43,7 +43,7 @@ this.$refs.usernameInput.focusInput()
 当 `ref` 与 `v-for` 一起使用时，你得到的 `ref` 将是一个数组，其中包含镜像数据源的子组件。
 
 :::warning
-`$refs` 仅在组件渲染后填充。它只用于直接子操作的转义图案填充——应避免从模板或计算属性中访问 `$refs`。
+`$refs` 只会在组件渲染完成之后生效。这仅作为一个用于直接操作子元素的“逃生舱”——你应该避免在模板或计算属性中访问 `$refs`。
 :::
 
 **参考**：[在 Composition API 中使用 template refs](/guide/composition-api-template-refs.html#template-refs)


### PR DESCRIPTION
The original translation was weird... And I noticed that the original content is nearly identical to the v2 version. So I copied the v2 translation with a minor change:

* "子组件" → "子元素", since I feel "元素" is more general than "组件", considering `$refs` works on both DOM elements and components.