### PR TITLE
fixed the locale config

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -206,7 +206,12 @@ const sidebar = {
 
 module.exports = {
   title: 'Vue.js',
-  description: 'Vue.js - The Progressive JavaScript Framework',
+  description: 'Vue.js - The 渐进式 JavaScript 框架',
+  locales: {
+    '/': {
+      lang: 'zh-CN'
+    }
+  },
   head: [
     [
       'link',


### PR DESCRIPTION
## Description of Problem

当前生成的站点的语言信息是 `<html lang="en-US">`

## Proposed Solution

修复之后是 `<html lang="zh-CN">`

## Additional Information
