### PR TITLE
docs: update component-slots.md

### DIFF
--- a/src/guide/component-slots.md
+++ b/src/guide/component-slots.md
@@ -309,10 +309,10 @@ app.component('todo-list', {
 ```html
 <!-- 无效，会导致警告 -->
 <todo-list v-slot="slotProps">
-  <todo-list v-slot:default="slotProps">
+  <template v-slot:default="slotProps">
     <i class="fas fa-check"></i>
     <span class="green">{{ slotProps.item }}</span>
-  </todo-list>
+  </template>
   <template v-slot:other="otherSlotProps">
     slotProps is NOT available here
   </template>

--- a/src/guide/component-slots.md
+++ b/src/guide/component-slots.md
@@ -309,10 +309,9 @@ app.component('todo-list', {
 ```html
 <!-- 无效，会导致警告 -->
 <todo-list v-slot="slotProps">
-  <template v-slot:default="slotProps">
-    <i class="fas fa-check"></i>
-    <span class="green">{{ slotProps.item }}</span>
-  </template>
+  <i class="fas fa-check"></i>
+  <span class="green">{{ slotProps.item }}</span>
+  
   <template v-slot:other="otherSlotProps">
     slotProps is NOT available here
   </template>


### PR DESCRIPTION
## Description of Problem

![image](https://user-images.githubusercontent.com/27997635/98527367-e74de980-22b5-11eb-9011-750867725bda.png)

从示例要表达的意思看，是要表达匿名插槽和具名插槽的作用域不能混用。黄框示例内todo-list嵌套todo-list后，与红框示例对比产生了歧义。

如果是的话，英文版文档似乎也存在该问题，如果理解错误，还请指正。谢谢

## Proposed Solution

将黄框内的 todo-list 替换为 template，修改为如下内容

![image](https://user-images.githubusercontent.com/27997635/98529557-b9b66f80-22b8-11eb-90a7-02db946621e1.png)

## Additional Information

