### PR TITLE
docs: fix markdown anchor

### DIFF
--- a/src/api/built-in-components.md
+++ b/src/api/built-in-components.md
@@ -206,7 +206,7 @@
   `<keep-alive>` 不会在函数式组件中正常工作，因为它们没有缓存实例。
   :::
 
--  **参考：** [动态组件 - keep-alive](../guide/component-dynamic-async.html#dynamic-components-with-keep-alive)
+-  **参考：** [动态组件 - keep-alive](../guide/component-dynamic-async.html#在动态组件上使用-keep-alive)
 
 ## slot
 
@@ -220,7 +220,7 @@
 
   详细用法，请参考下面教程的链接。
 
--  **参考：** [通过插槽分发内容](../guide/component-basics.html#content-distribution-with-slots)
+-  **参考：** [通过插槽分发内容](../guide/component-basics.html#通过插槽分发内容)
 
 ## teleport
 

--- a/src/api/global-api.md
+++ b/src/api/global-api.md
@@ -160,7 +160,7 @@ const AsyncComp = defineAsyncComponent(() =>
 app.component('async-component', AsyncComp)
 ```
 
-当使用[局部注册](../guide/component-registration.html#local-registration)时，你也可以直接提供一个返回 `Promise` 的函数：
+当使用[局部注册](../guide/component-registration.html#局部注册)时，你也可以直接提供一个返回 `Promise` 的函数：
 ```js
 import { createApp, defineAsyncComponent } from 'vue'
 

--- a/src/api/instance-methods.md
+++ b/src/api/instance-methods.md
@@ -193,7 +193,7 @@
 
   For more information about `flush` see [Effect Flush Timing](../guide/reactivity-computed-watchers.html#effect-flush-timing).
 
--  **参考** [Watchers](../guide/computed.html#watchers)
+-  **参考** [Watchers](../guide/computed.html#侦听器)
 
 ## $emit
 
@@ -270,7 +270,7 @@
 
 -  **参考**
   - [`emits` 选项](./options-data.html#emits)
-  - [事件抛出一个值](../guide/component-basics.html#emitting-a-value-with-an-event)
+  - [事件抛出一个值](../guide/component-basics.html#使用事件抛出一个值)
 
 ## $forceUpdate
 

--- a/src/api/instance-properties.md
+++ b/src/api/instance-properties.md
@@ -80,7 +80,7 @@
 
 - **详细：**
 
-  用来访问被[插槽分发](../guide/component-basics.html#content-distribution-with-slots)的内容。每个[具名插槽](../guide/component-slots.html#named-slots)有其相应的 property (例如：`v-slot:foo` 中的内容将会在 `this.$slots.foo` 中被找到)。`default` property 包括了所有没有被包含在具名插槽中的节点，或 `v-slot:default` 的内容。
+  用来访问被[插槽分发](../guide/component-basics.html#通过插槽分发内容)的内容。每个[具名插槽](../guide/component-slots.html#具名插槽)有其相应的 property (例如：`v-slot:foo` 中的内容将会在 `this.$slots.foo` 中被找到)。`default` property 包括了所有没有被包含在具名插槽中的节点，或 `v-slot:default` 的内容。
 
   在使用[渲染函数](../guide/render-function.html)书写一个组件时，访问 `this.$slots` 最有帮助。
 
@@ -120,8 +120,8 @@
 
 -  **参考**
   - [`<slot>` 组件](built-in-components.html#slot)
-  - [通过插槽分发内容](../guide/component-basics.html#content-distribution-with-slots)
-  - [渲染函数 - 插槽](../guide/render-function.html#slots)
+  - [通过插槽分发内容](../guide/component-basics.html#通过插槽分发内容)
+  - [渲染函数 - 插槽](../guide/render-function.html#插槽)
 
 ## $refs
 

--- a/src/api/options-data.md
+++ b/src/api/options-data.md
@@ -48,13 +48,13 @@
 
   你可以基于对象的语法使用以下选项：
 
-  - `type`：可以是下列原生构造函数中的一种：`String`、`Number`、`Boolean`、`Array`、`Object`、`Date`、`Function`、`Symbol`、任何自定义构造函数、或上述内容组成的数组。会检查一个 prop 是否是给定的类型，否则抛出警告。Prop 类型的[更多信息在此](../guide/component-props.html#prop-types)。
+  - `type`：可以是下列原生构造函数中的一种：`String`、`Number`、`Boolean`、`Array`、`Object`、`Date`、`Function`、`Symbol`、任何自定义构造函数、或上述内容组成的数组。会检查一个 prop 是否是给定的类型，否则抛出警告。Prop 类型的[更多信息在此](../guide/component-props.html#prop-类型)。
   - `default`：`any`
     为该 prop 指定一个默认值。如果该 prop 没有被传入，则换做用这个值。对象或数组的默认值必须从一个工厂函数返回
   - `required`：`Boolean`
     义该 prop 是否是必填项。在非生产环境中，如果这个值为 truthy 且该 prop 没有被传入的，则一个控制台警告将会被抛出。
   - `validator`：`Function`
-    自定义验证函数会将该 prop 的值作为唯一的参数代入。在非生产环境下，如果该函数返回一个 falsy 的值 (也就是验证失败)，一个控制台警告将会被抛出。你可以在[这里](../guide/component-props.html#prop-validation)查阅更多 prop 验证的相关信息。
+    自定义验证函数会将该 prop 的值作为唯一的参数代入。在非生产环境下，如果该函数返回一个 falsy 的值 (也就是验证失败)，一个控制台警告将会被抛出。你可以在[这里](../guide/component-props.html#prop-验证)查阅更多 prop 验证的相关信息。
 
 - **示例：**
 
@@ -248,7 +248,7 @@
 
   :::
 
--  **参考** [Watchers](../guide/computed.html#watchers)
+-  **参考** [Watchers](../guide/computed.html#侦听器)
 
 ## emits
 

--- a/src/api/options-dom.md
+++ b/src/api/options-dom.md
@@ -19,8 +19,8 @@
   :::
 
 -  **参考**
-  - [生命周期图示](../guide/instance.html#lifecycle-diagram)
-  - [通过插槽分发内容](../guide/component-basics.html#content-distribution-with-slots)
+  - [生命周期图示](../guide/instance.html#生命周期图示)
+  - [通过插槽分发内容](../guide/component-basics.html#通过插槽分发内容)
 
 ## render
 

--- a/src/api/options-lifecycle-hooks.md
+++ b/src/api/options-lifecycle-hooks.md
@@ -12,7 +12,7 @@
 
   在实例初始化之后，数据观测 (data observer) 和 event/watcher 事件配置之前被调用。
 
--  **参考：**[生命周期图示](../guide/instance.html#lifecycle-diagram)
+-  **参考：**[生命周期图示](../guide/instance.html#生命周期图示)
 
 ## created
 
@@ -22,7 +22,7 @@
 
   在实例创建完成后被立即调用。在这一步，实例已完成以下的配置：数据观测 (data observer)，property 和方法的运算，watch/event 事件回调。然而，挂载阶段还没开始，`$el` property 目前尚不可用。
 
--  **参考：**[生命周期图示](../guide/instance.html#lifecycle-diagram)
+-  **参考：**[生命周期图示](../guide/instance.html#生命周期图示)
 
 ## beforeMount
 
@@ -34,7 +34,7 @@
 
   **该钩子在服务器端渲染期间不被调用。**
 
--  **参考：**[生命周期图示](../guide/instance.html#lifecycle-diagram)
+-  **参考：**[生命周期图示](../guide/instance.html#生命周期图示)
 
 ## mounted
 
@@ -56,7 +56,7 @@
 
   **该钩子在服务器端渲染期间不被调用。**
 
--  **参考：**[生命周期图示](../guide/instance.html#lifecycle-diagram)
+-  **参考：**[生命周期图示](../guide/instance.html#生命周期图示)
 
 ## beforeUpdate
 
@@ -68,7 +68,7 @@
 
   **该钩子在服务器端渲染期间不被调用，因为只有初次渲染会在服务端进行。**
 
--  **参考：**[生命周期图示](../guide/instance.html#lifecycle-diagram)
+-  **参考：**[生命周期图示](../guide/instance.html#生命周期图示)
 
 ## updated
 
@@ -92,7 +92,7 @@
 
   **该钩子在服务器端渲染期间不被调用。**
 
--  **参考：**[生命周期图示](../guide/instance.html#lifecycle-diagram)
+-  **参考：**[生命周期图示](../guide/instance.html#生命周期图示)
 
 ## activated
 
@@ -130,7 +130,7 @@
 
   **该钩子在服务器端渲染期间不被调用。**
 
--  **参考：**[生命周期图示](../guide/instance.html#lifecycle-diagram)
+-  **参考：**[生命周期图示](../guide/instance.html#生命周期图示)
 
 ## unmounted
 
@@ -142,7 +142,7 @@
 
   **该钩子在服务器端渲染期间不被调用。**
 
--  **参考：**[生命周期图示](../guide/instance.html#lifecycle-diagram)
+-  **参考：**[生命周期图示](../guide/instance.html#生命周期图示)
 
 ## errorCaptured
 

--- a/src/api/refs-api.md
+++ b/src/api/refs-api.md
@@ -209,7 +209,7 @@ foo.value = {}
 isReactive(foo.value) // false
 ```
 
-**参考**：[正在将独立的响应式值创建为 `refs`](../guide/reactivity-fundamentals.html#creating-standalone-reactive-values-as-refs)
+**参考**：[正在将独立的响应式值创建为 `refs`](../guide/reactivity-fundamentals.html#创建独立的响应式值作为-refs)
 
 ## `triggerRef`
 

--- a/src/api/special-attributes.md
+++ b/src/api/special-attributes.md
@@ -71,4 +71,4 @@
 
 -  **参考**
   - [动态组件](../guide/component-dynamic-async.html)
-  - [DOM 模板解析说明](../guide/component-basics.html#dom-template-parsing-caveats)
+  - [DOM 模板解析说明](../guide/component-basics.html#解析-dom-模板时的注意事项)

--- a/src/guide/component-custom-events.md
+++ b/src/guide/component-custom-events.md
@@ -157,7 +157,7 @@ app.component('user-name', {
 在 2.x 中，我们对组件 `v-model` 上的 `.trim` 等修饰符提供了硬编码支持。但是，如果组件可以支持自定义修饰符，则会更有用。在 3.x 中，添加到组件 `v-model` 的修饰符将通过 `modelModifiers` prop 提供给组件：
 
 
-当我们学习表单输入绑定时，我们看到 `v-model` 有[内置修饰符](/guide/forms.html#modifiers)——`.trim`、`.number` 和 `.lazy`。但是，在某些情况下，你可能还需要添加自己的自定义修饰符。
+当我们学习表单输入绑定时，我们看到 `v-model` 有[内置修饰符](/guide/forms.html#修饰符)——`.trim`、`.number` 和 `.lazy`。但是，在某些情况下，你可能还需要添加自己的自定义修饰符。
 
 让我们创建一个示例自定义修饰符 `capitalize`，它将 `v-model` 绑定提供的字符串的第一个字母大写。
 

--- a/src/guide/component-slots.md
+++ b/src/guide/component-slots.md
@@ -374,7 +374,7 @@ function (slotProps) {
 
 ## 动态插槽名
 
-[动态指令参数](template-syntax.md#dynamic-arguments)也可以用在 `v-slot` 上，来定义动态的插槽名：
+[动态指令参数](template-syntax.md#动态参数)也可以用在 `v-slot` 上，来定义动态的插槽名：
 
 ```html
 <base-layout>

--- a/src/guide/composition-api-template-refs.md
+++ b/src/guide/composition-api-template-refs.md
@@ -4,7 +4,7 @@
 
 > 本指南假定你已经阅读了[组合式 API 简介](composition-api-introduction.html)和[响应性基础](reactivity-fundamentals.html)。如果你不熟悉组合式 API，请先阅读此文章。
 
-在使用组合式 API 时，[响应式引用](reactivity-fundamentals.html#creating-standalone-reactive-values-as-refs)和[模板引用](component-template-refs.html)的概念是统一的。为了获得对模板内元素或组件实例的引用，我们可以像往常一样声明 ref 并从 [setup()](composition-api-setup.html) 返回：
+在使用组合式 API 时，[响应式引用](reactivity-fundamentals.html#创建独立的响应式值作为-refs)和[模板引用](component-template-refs.html)的概念是统一的。为了获得对模板内元素或组件实例的引用，我们可以像往常一样声明 ref 并从 [setup()](composition-api-setup.html) 返回：
 
 ```html
 <template> 

--- a/src/guide/forms.md
+++ b/src/guide/forms.md
@@ -327,4 +327,4 @@ vm.selected.number // => 123
 
 HTML 原生的输入元素类型并不总能满足需求。幸好，Vue 的组件系统允许你创建具有完全自定义行为且可复用的输入组件。这些输入组件甚至可以和 `v-model` 一起使用！
 
-要了解更多，请参阅组件指南中的[自定义输入](./component-basics.html#using-v-model-on-components)组件。
+要了解更多，请参阅组件指南中的[自定义输入](./component-basics.html#在组件上使用-v-model)组件。

--- a/src/guide/migration/v-model.md
+++ b/src/guide/migration/v-model.md
@@ -186,6 +186,6 @@ this.$emit('update:title', newValue)
 ## 下一步
 
 更多新的 `v-model` 语法相关信息，请参考：
-- [在组件中使用 `v-model`](../component-basics.html#using-v-model-on-components) 
-- [`v-model` 参数](../component-custom-events.html#v-model-arguments)
-- [处理 `v-model` 修饰符](../component-custom-events.html#v-model-arguments)
+- [在组件中使用 `v-model`](../component-basics.html#在组件上使用-v-model) 
+- [`v-model` 参数](../component-custom-events.html#v-model-参数)
+- [处理 `v-model` 修饰符](../component-custom-events.html#处理-v-model-修饰符)

--- a/src/guide/state-management.md
+++ b/src/guide/state-management.md
@@ -10,7 +10,7 @@
 
 ## 简单状态管理起步使用
 
-经常被忽略的是，Vue 应用中响应式 `data` 对象的实际来源——当访问数据对象时，一个组件实例只是简单的代理访问。所以，如果你有一处需要被多个实例间共享的状态，你可以使用一个 [reactive](/guide/reactivity-fundamentals.html#declaring-reactive-state) 方法让对象作为响应式对象。
+经常被忽略的是，Vue 应用中响应式 `data` 对象的实际来源——当访问数据对象时，一个组件实例只是简单的代理访问。所以，如果你有一处需要被多个实例间共享的状态，你可以使用一个 [reactive](/guide/reactivity-fundamentals.html#声明响应式状态) 方法让对象作为响应式对象。
 
 ```js
 const sourceOfTruth = Vue.reactive({


### PR DESCRIPTION
## Description of Problem
v3中文文档部分超链接指向的英文标题，不能跳转到对应的章节。

## Proposed Solution
将markdown锚点修复为中文标题。
