### PR TITLE
fix: Image loss due to image path

### DIFF
--- a/src/.vuepress/styles/index.styl
+++ b/src/.vuepress/styles/index.styl
@@ -48,7 +48,7 @@
     background-color: #f8f8f8;
 
     &::before {
-      content: url('/images/icons/info.svg');
+      content: url('/docs/images/icons/info.svg');
       width: 25px;
       height: 25px;
       left: -16px;
@@ -61,7 +61,7 @@
     background-color: #f8f8f8;
 
     &::before {
-      content: url('/images/icons/bulb.svg');
+      content: url('/docs/images/icons/bulb.svg');
       width: 25px;
       height: 25px;
       left: -16px;
@@ -77,7 +77,7 @@
     }
 
     &::before {
-      content: url('/images/icons/danger.svg');
+      content: url('/docs/images/icons/danger.svg');
       width: 25px;
       height: 25px;
       left: -16px;
@@ -94,7 +94,7 @@
     }
 
     &::before {
-      content: url('/images/icons/stop.svg');
+      content: url('/docs/images/icons/stop.svg');
       width: 25px;
       height: 25px;
       left: -16px;

--- a/src/.vuepress/theme/styles/vuemastery-banner.styl
+++ b/src/.vuepress/theme/styles/vuemastery-banner.styl
@@ -37,7 +37,7 @@ animOut = all cubic-bezier(0.34, 0.06, 0.01, 1) 1s
     width 100%
     position absolute
     transition animIn
-    background-image url(/images/vuemastery/background.png)
+    background-image url(/docs/images/vuemastery/background.png)
     background-position center
     background-size: 100% auto;
     top 0
@@ -221,7 +221,7 @@ animOut = all cubic-bezier(0.34, 0.06, 0.01, 1) 1s
     width 100%
     top 0
     right 0
-    background-image url(/images/vuemastery/black-hole.png)
+    background-image url(/docs/images/vuemastery/black-hole.png)
     background-attachment fixed
     background-size: auto 200px;
     background-position: top -52px right -24px;
@@ -233,7 +233,7 @@ animOut = all cubic-bezier(0.34, 0.06, 0.01, 1) 1s
       background-position: top -81px right -82px;
 
   &:after
-    background-image: url(/images/vuemastery/planets.png);
+    background-image: url(/docs/images/vuemastery/planets.png);
     transition: all cubic-bezier(0.34, 0.06, 0.01, 1) 3s;
     background-position: left -80px top -80px;
     background-size: auto 180px;

--- a/src/cookbook/debugging-in-vscode.md
+++ b/src/cookbook/debugging-in-vscode.md
@@ -43,7 +43,7 @@ We're assuming the port to be `8080` here. If it's not the case (for instance, i
 
 Click on the Debugging icon in the Activity Bar to bring up the Debug view, then click on the gear icon to configure a launch.json file, selecting **Chrome/Firefox: Launch** as the environment. Replace content of the generated launch.json with the corresponding configuration:
 
-![Add Chrome Configuration](/images/config_add.png)
+![Add Chrome Configuration](/docs/images/config_add.png)
 
 ```json
 {
@@ -76,7 +76,7 @@ Click on the Debugging icon in the Activity Bar to bring up the Debug view, then
 
 1.  Set a breakpoint in **src/components/HelloWorld.vue** on `line 90` where the `data` function returns a string.
 
-![Breakpoint Renderer](/images/breakpoint_set.png)
+![Breakpoint Renderer](/docs/images/breakpoint_set.png)
 
 2.  Open your favorite terminal at the root folder and serve the app using Vue CLI:
 
@@ -88,7 +88,7 @@ npm run serve
 
 4.  Your breakpoint should now be hit as a new browser instance opens `http://localhost:8080`.
 
-![Breakpoint Hit](/images/breakpoint_hit.png)
+![Breakpoint Hit](/docs/images/breakpoint_hit.png)
 
 ## Alternative Patterns
 
@@ -96,7 +96,7 @@ npm run serve
 
 There are other methods of debugging, varying in complexity. The most popular and simple of which is to use the excellent Vue.js devtools [for Chrome](https://chrome.google.com/webstore/detail/vuejs-devtools/nhdogjmejiglipccpnnnanhbledajbpd) and [for Firefox](https://addons.mozilla.org/en-US/firefox/addon/vue-js-devtools/). Some of the benefits of working with the devtools are that they enable you to live-edit data properties and see the changes reflected immediately. The other major benefit is the ability to do time travel debugging for Vuex.
 
-![Devtools Timetravel Debugger](/images/devtools-timetravel.gif)
+![Devtools Timetravel Debugger](/docs/images/devtools-timetravel.gif)
 
 Please note that if the page uses a production/minified build of Vue.js (such as the standard link from a CDN), devtools inspection is disabled by default so the Vue pane won't show up. If you switch to an unminified version, you may have to give the page a hard refresh to see them.
 

--- a/src/guide/a11y-semantics.md
+++ b/src/guide/a11y-semantics.md
@@ -38,7 +38,7 @@
 
 如果你在 chrome 开发工具中检查这个元素，并打开 Elements 选项卡中的 Accessibility 选项卡，你将看到输入是如何从标签中获取其名称的：
 
-![Chrome开发工具显示可从标签输入的可访问名称](/images/AccessibleLabelChromeDevTools.png)
+![Chrome开发工具显示可从标签输入的可访问名称](/docs/images/AccessibleLabelChromeDevTools.png)
 
 :::warning 警告：
 
@@ -73,7 +73,7 @@
 
 请随意在 Chrome DevTools 中检查此元素，以查看可访问名称是如何更改的：
 
-![Chrome Developer Tools showing input accessible name from aria-label](/images/AccessibleARIAlabelDevTools.png)
+![Chrome Developer Tools showing input accessible name from aria-label](/docs/images/AccessibleARIAlabelDevTools.png)
 
 #### aria-labelledby
 
@@ -103,7 +103,7 @@
 
 <common-codepen-snippet title="Form ARIA labelledby" slug="ZEQXOLP" :height="265" tab="js,result" :team="false" user="mlama007" name="Maria" theme="light" :preview="false" :editable="false" />
 
-![Chrome Developer Tools showing input accessible name from aria-labelledby](/images/AccessibleARIAlabelledbyDevTools.png)
+![Chrome Developer Tools showing input accessible name from aria-labelledby](/docs/images/AccessibleARIAlabelledbyDevTools.png)
 
 #### aria-describedby
 
@@ -137,7 +137,7 @@
 
 你可以通过使用 Chrome 开发工具来查看说明：
 
-![Chrome开发工具显示aria-labelledby的输入可访问名称和aria-describedby的描述](/images/AccessibleARIAdescribedby.png)
+![Chrome开发工具显示aria-labelledby的输入可访问名称和aria-describedby的描述](/docs/images/AccessibleARIAdescribedby.png)
 
 ### 占位符
 

--- a/src/guide/component-basics.md
+++ b/src/guide/component-basics.md
@@ -61,7 +61,7 @@ app.mount('#components-demo')
 
 通常一个应用会以一棵嵌套的组件树的形式来组织：
 
-![Component Tree](/images/components.png)
+![Component Tree](/docs/images/components.png)
 
 例如，你可能会有页头、侧边栏、内容区等组件，每个组件又包含了其它的像导航链接、博文之类的组件。
 

--- a/src/guide/component-provide-inject.md
+++ b/src/guide/component-provide-inject.md
@@ -6,7 +6,7 @@
 
 对于这种情况，我们可以使用 `provide` 和 `inject` 对。父组件可以作为其所有子组件的依赖项提供程序，而不管组件层次结构有多深。这个特性有两个部分：父组件有一个 `provide` 选项来提供数据，子组件有一个 `inject` 选项来开始使用这个数据。
 
-![Provide/inject scheme](/images/components_provide.png)
+![Provide/inject scheme](/docs/images/components_provide.png)
 
 例如，如果我们有这样的层次结构：
 

--- a/src/guide/introduction.md
+++ b/src/guide/introduction.md
@@ -217,7 +217,7 @@ Vue.createApp(ListRendering).mount('#list-rendering')
 
 组件系统是 Vue 的另一个重要概念，因为它是一种抽象，允许我们使用小型、独立和通常可复用的组件构建大型应用。仔细想想，几乎任意类型的应用界面都可以抽象为一个组件树：
 
-![Component Tree](/images/components.png)
+![Component Tree](/docs/images/components.png)
 
 在 Vue 中，组件本质上是一个具有预定义选项的实例。在 Vue 中注册组件很简单：如对 `App` 对象所做的那样创建一个组件对象，并将其定义在父级组件的 `components` 选项中：
 

--- a/src/guide/migration/v-model.md
+++ b/src/guide/migration/v-model.md
@@ -119,7 +119,7 @@ this.$emit('update:title', newValue)
 <ChildComponent :title="pageTitle" @update:title="pageTitle = $event" />
 ```
 
-![v-bind anatomy](/images/v-bind-instead-of-sync.png)
+![v-bind anatomy](/docs/images/v-bind-instead-of-sync.png)
 
 这也可以作为 `.sync` 修饰符的替代，而且允许我们在自定义组件上使用多个 `v-model`。
 

--- a/src/guide/render-function.md
+++ b/src/guide/render-function.md
@@ -95,7 +95,7 @@ app.component('anchored-heading', {
 
 上述 HTML 对应的 DOM 节点树如下图所示
 
-![DOM Tree Visualization](/images/dom-tree.png)
+![DOM Tree Visualization](/docs/images/dom-tree.png)
 
 每个元素都是一个节点。每段文字也是一个节点。甚至注释也都是节点。一个节点就是页面的一个部分。就像家谱树一样，每个节点都可以有孩子节点 (也就是说每个部分可以包含其它的一些部分)。
 

--- a/src/guide/state-management.md
+++ b/src/guide/state-management.md
@@ -110,7 +110,7 @@ const appB = Vue.createApp({
 }).mount('#app-b')
 ```
 
-![State Management](/images/state.png)
+![State Management](/docs/images/state.png)
 
 :::tip
 重要的是，注意你不应该在 action 中替换原始的状态对象——组件和 store 需要引用同一个共享对象，变更才能够被观察到。

--- a/src/guide/transitions-enterleave.md
+++ b/src/guide/transitions-enterleave.md
@@ -82,7 +82,7 @@ Vue.createApp(Demo).mount('#demo')
 
 6. `v-leave-to`：离开过渡的结束状态。在离开过渡被触发之后下一帧生效 (与此同时 `v-leave-from` 被删除)，在过渡/动画完成之后移除。
 
-![Transition Diagram](/images/transition.png)
+![Transition Diagram](/docs/images/transition.png)
 
 对于这些在过渡中切换的类名来说，如果你使用一个没有名字的 `<transition>`，则 `v-` 是这些class名的默认前缀。如果你使用了 `<transition name="my-transition">`，那么 `v-enter-from`会替换为 `my-transition-enter-from`。
 

--- a/src/guide/transitions-overview.md
+++ b/src/guide/transitions-overview.md
@@ -180,7 +180,7 @@ Easing 也可以表达动画元素的质量。以下面的 Pen 为例，你认�
 
 虽然使用 cubic-bezier ease 提供的两个控制柄可以为简单的动画获得很好的效果，但是 JavaScript 允许多个控制柄，以此支持更多的变化。
 
-![Ease 比较](/images/css-vs-js-ease.svg)
+![Ease 比较](/docs/images/css-vs-js-ease.svg)
 
 以弹跳为例。在 CSS 中，我们必须声明向上和向下的每个关键帧。在 JavaScript 中，我们可以通过在 [greensock API(GSAP)](https://greensock.com/) 中声明 `bounce` 来描述 ease 中所有这些移动 (其他 JS 库有其他类型的 easing 默认值)。
 


### PR DESCRIPTION
问题：官网的图片丢失。
解决：修改丢失文件路径：增加/docs/前缀。
备注：带有src的img标签的图片正常显示，只修改md中丢失的图片路径。