### PR TITLE
fix: mixins typo

### DIFF
--- a/src/guide/mixins.md
+++ b/src/guide/mixins.md
@@ -196,7 +196,7 @@ app.mixin({
 })
 ```
 
-如你所见，在控制台中，我们先从 mixin 打印 `toVal` 和 `fromVal`，然后从 `app` 打印。如果存在，我们总是返回 `fromVal`，这就是为什么 `this.$options.custom` 设置为 `hello！` 最后。让我们尝试将策略更改为*始终*从子*实例*返回值：
+如你所见，在控制台中，我们先从 mixin 打印 `toVal` 和 `fromVal`，然后从 `app` 打印。如果存在，我们总是返回 `fromVal`，这就是为什么 `this.$options.custom` 设置为 `hello!` 最后。让我们尝试将策略更改为*始终*从子*实例*返回值：
 
 ```js
 const app = Vue.createApp({

--- a/src/guide/mixins.md
+++ b/src/guide/mixins.md
@@ -62,14 +62,14 @@ const app = Vue.createApp({
 ```js
 const myMixin = {
   created() {
-    console.log('mixin hook called')
+    console.log('混入对象的钩子被调用')
   }
 }
 
 const app = Vue.createApp({
   mixins: [myMixin],
   created() {
-    console.log('component hook called')
+    console.log('组件钩子被调用')
   }
 })
 
@@ -196,7 +196,7 @@ app.mixin({
 })
 ```
 
-如你所见，在控制台中，我们先从 mixin 打印 `toVal` 和 `fromVal`，然后从 `app` 打印。如果存在，我们总是返回 `fromVal`，这就是为什么 `this.$options.custom` 设置为 `你好！` 最后。让我们尝试将策略更改为*始终*从子*实例*返回值：
+如你所见，在控制台中，我们先从 mixin 打印 `toVal` 和 `fromVal`，然后从 `app` 打印。如果存在，我们总是返回 `fromVal`，这就是为什么 `this.$options.custom` 设置为 `hello！` 最后。让我们尝试将策略更改为*始终*从子*实例*返回值：
 
 ```js
 const app = Vue.createApp({


### PR DESCRIPTION
## Description of Problem

[混入-选项合并](https://v3.cn.vuejs.org/guide/mixins.html#%E9%80%89%E9%A1%B9%E5%90%88%E5%B9%B6)的`console.log`可统一为中文。同[v2 - 混入-选项合并](https://cn.vuejs.org/v2/guide/mixins.html#%E9%80%89%E9%A1%B9%E5%90%88%E5%B9%B6)

