### PR TITLE
update: translate composition-api-setup.md

### DIFF
--- a/src/guide/composition-api-setup.md
+++ b/src/guide/composition-api-setup.md
@@ -60,7 +60,7 @@ setup(props) {
 }
 ```
 
-### 上下文
+### Context
 
 传递给 `setup` 函数的第二个参数是 `context`。`context` 是一个普通的 JavaScript 对象，它暴露三个组件的 property：
 

--- a/src/guide/composition-api-setup.md
+++ b/src/guide/composition-api-setup.md
@@ -48,9 +48,8 @@ setup(props) {
 }
 ```
 
-<!-- TODO: translation -->
 
-If `title` is an optional prop, it could be missing from `props`. In that case, `toRefs` won't create a ref for `title`. Instead you'd need to use `toRef`:
+如果 `title` 是可选的 prop，则传入的 `props` 中可能没有 `title` 。在这种情况下，`toRefs` 将不会为 `title` 创建一个 ref 。你需要使用 `toRef` 替代它：
 
 ```js
 // MyBook.vue


### PR DESCRIPTION
翻译：当解构可选的props属性时，当可选属性未传入而需解构该属性时，使用 toRef 代替 toRefs
