### PR TITLE
feat: add github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report (Bug 报告)
+about: 反馈文档报错，先看下是不是找错仓库了。本仓库仅维护一个 Vuejs 3.0 官方中文站点(https://v3.cn.vuejs.org/) 。
+title: 'bug: '
+labels: ''
+assignees: ''
+
+---
+
+<!--     placeholder content      -->
+
+首先感谢大家，向我们反馈 Vuejs 3.0 官方中文仓库反馈文档错误。
+
+近期发现多例用户通过 issue、PR 反馈文档错误，经过查证，均为第三方维护者所属的网站。
+
+本仓库仅维护一个 Vuejs 3.0 官方中文站点，即为 `v3.cn.vuejs.org`。
+
+如果你发现一个文档错误，我们非常欢迎你能够发起 PR 来修复该问题。
+
+【更多】：
+
+1. 如何参与文档翻译？请看此处，[集中翻译和校对工作汇总](https://github.com/vuejs/docs-next-zh-cn/issues/18)。
+
+2. [术语翻译约定](https://github.com/vuejs/docs-next-zh-cn/wiki/%E6%9C%AF%E8%AF%AD%E7%BF%BB%E8%AF%91%E7%BA%A6%E5%AE%9A)
+
+3. [协作指南](https://github.com/vuejs/docs-next-zh-cn/wiki/%E5%8D%8F%E4%BD%9C%E6%8C%87%E5%8D%97)

--- a/.github/ISSUE_TEMPLATE/default.md
+++ b/.github/ISSUE_TEMPLATE/default.md
@@ -1,0 +1,10 @@
+---
+name: Default (默认)
+about: 本仓库 issue 目前适用于讨论文档内容本身，如翻译、校对、修饰文档等
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+


### PR DESCRIPTION
根据讨论，添加了两个 `issue template`:

1. bug report template，适用于文档纠错
2. default template, 适用于任意格式

## 效果

![image](https://user-images.githubusercontent.com/8652596/103741961-ff7f8200-5034-11eb-9bee-3e665a444469.png)

bug report template:
![image](https://user-images.githubusercontent.com/8652596/103742024-1c1bba00-5035-11eb-9982-f7cb6a3c4a14.png)

（其他补充：如果可以的话，有中英双语可能会更加恰当）

@jinjiang @Justineo 

另外，英文主站，已添加了中文站点入口：v3.vuejs.org
