### PR TITLE
fix: fix the translation of v-if used with v-for

### DIFF
--- a/src/api/directives.md
+++ b/src/api/directives.md
@@ -62,7 +62,7 @@
 
   当条件变化时该指令触发过渡效果。
 
-  当和 `v-if` 一起使用时，`v-if` 的优先级比 `v-for` 更高。详见[列表渲染教程](/guide/list.html#v-for-与-v-if-一同使用)
+  当和 `v-for` 一起使用时，`v-if` 的优先级比 `v-for` 更高。详见[列表渲染教程](/guide/list.html#v-for-与-v-if-一同使用)
 
 - **参考**：[条件渲染 - v-if](../guide/conditional.html#v-if)
 


### PR DESCRIPTION
应该是和v-for一起使用。
![image](https://user-images.githubusercontent.com/52165593/108156792-48d6ed00-711c-11eb-84e4-d5cc28fac5a3.png)
