### PR TITLE
[fix] 修正resolveComponent未找到返回的值

### DIFF
--- a/src/api/global-api.md
+++ b/src/api/global-api.md
@@ -227,7 +227,7 @@ const AsyncComp = defineAsyncComponent({
 
 如果在当前应用实例中可用，则允许按名称解析 `component`。
 
-返回一个 `Component`。如果没有找到，则返回 `undefined`。
+返回一个 `Component`。如果没有找到，则返回接收的参数 `name`。
 
 ```js
 const app = Vue.createApp({})


### PR DESCRIPTION
## Description of Problem
`resolveComponent(component)`未找到返回的应该是传入的参数`component`而非`undefined`。 
源码： https://github.com/vuejs/vue-next/blob/82bf7ebf36833679f13039e5b0282eff2859e18f/packages/runtime-core/src/helpers/resolveAssets.ts#L20
