### PR TITLE
doc: fix composition-api-setup code indent

### DIFF
--- a/src/guide/composition-api-setup.md
+++ b/src/guide/composition-api-setup.md
@@ -42,9 +42,9 @@ export default {
 import { toRefs } from 'vue'
 
 setup(props) {
-	const { title } = toRefs(props)
+  const { title } = toRefs(props)
 
-	console.log(title.value)
+  console.log(title.value)
 }
 ```
 
@@ -55,8 +55,8 @@ setup(props) {
 // MyBook.vue
 import { toRef } from 'vue'
 setup(props) {
-	const title = toRef(props, 'title')
-	console.log(title.value)
+  const title = toRef(props, 'title')
+  console.log(title.value)
 }
 ```
 


### PR DESCRIPTION
## Description of Problem

Tab used as code style indent in [composition-api-setup guide](https://v3.cn.vuejs.org/guide/composition-api-setup.html#props), cause in inconsistency code style.

![image](https://user-images.githubusercontent.com/41824968/117675842-86a95600-b1df-11eb-92ed-44f9a4eb1a84.png)

## Proposed Solution

Replace tab using 2 space.

## Additional Information

https://github.com/vuejs/docs-next/pull/858