### PR TITLE
docs: 更好的语言组织

### DIFF
--- a/src/guide/typescript-support.md
+++ b/src/guide/typescript-support.md
@@ -96,7 +96,7 @@ const Component = defineComponent({
 
 ## 与 Options API 一起使用
 
-TypeScript 应该能够在不显式定义类型的情况下推断大多数类型。例如，一个组件有一个数字类型的 `count` property，如果试图对其调用字符串独有的方法，则会出现错误：
+TypeScript 应该能够在不显式定义类型的情况下推断大多数类型。例如，对于拥有一个数字类型的 `count` property 的组件来说，如果你试图对其调用字符串独有的方法，会出现错误：
 
 ```ts
 const Component = defineComponent({

--- a/src/guide/typescript-support.md
+++ b/src/guide/typescript-support.md
@@ -96,7 +96,7 @@ const Component = defineComponent({
 
 ## 与 Options API 一起使用
 
-TypeScript 应该能够在不显式定义类型的情况下推断大多数类型。例如，如果有一个具有数字 `count` property 的组件，如果试图对其调用特定于字符串的方法，则会出现错误：
+TypeScript 应该能够在不显式定义类型的情况下推断大多数类型。例如，一个组件有一个数字类型的 `count` property，如果试图对其调用字符串独有的方法，则会出现错误：
 
 ```ts
 const Component = defineComponent({


### PR DESCRIPTION
英文：For example, if you have a component with a number count property, you will have an error if you try to call a string-specific method on it:
现有翻译指代混乱，这里应该指代的是数字类型的 count property 而不是拥有这个 property 的组件。另外前后两个”如果“连着用，读起来很拗口。
于是调整了语言组织，读起来更顺口，也更”白话“一些。