### PR TITLE
docs(composition-api): 修正composition-api翻译错误

### DIFF
--- a/src/api/composition-api.md
+++ b/src/api/composition-api.md
@@ -28,7 +28,7 @@ function setup(props: Data, context: SetupContext): Data
 ```
 
 :::tip
-若要获取传递给 `setup()` 的参数的类型推断，请使用 [defineComponent](global-api.html#definecomponent) 是需要的。
+在 [defineComponent](global-api.html#definecomponent) 中通过 `setup` function 定义组件时，可以通过定义传递参数的类型进行类型推断
 :::
 
 - **示例：**

--- a/src/api/composition-api.md
+++ b/src/api/composition-api.md
@@ -28,7 +28,7 @@ function setup(props: Data, context: SetupContext): Data
 ```
 
 :::tip
-在 [defineComponent](global-api.html#definecomponent) 中通过 `setup` function 定义组件时，可以通过定义传递参数的类型进行类型推断
+若要对传递给 `setup()` 的参数进行类型推断，你需要使用 [defineComponent](global-api.html#definecomponent)。
 :::
 
 - **示例：**


### PR DESCRIPTION
## Description of Problem
[有歧义的地址链接](https://v3.cn.vuejs.org/api/composition-api.html#setup)

英文文档中的原句是：
```
To get type inference for the arguments passed to setup(), the use of defineComponent is needed.
```
中文文档中翻译的是：
```
若要获取传递给 setup() 的参数的类型推断，请使用 defineComponent 是需要的。
```

翻译后的句子存在语句不通顺的问题，联系上下文可以使用
```
在 defineComponent 中通过 setup function 定义组件时，可以通过定义传递参数的类型进行类型推断
```

## Proposed Solution

## Additional Information
