### PR TITLE
docs: fix a tiny markdown grammar mistake

### DIFF
--- a/src/guide/component-slots.md
+++ b/src/guide/component-slots.md
@@ -274,7 +274,7 @@ app.component('todo-list', {
 </ul>
 ```
 
-绑定在 `<slot` > 元素上的 attribute 被称为**插槽 prop**。现在在父级作用域中，我们可以使用带值的 `v-slot` 来定义我们提供的插槽 prop 的名字：
+绑定在 `<slot>` 元素上的 attribute 被称为**插槽 prop**。现在在父级作用域中，我们可以使用带值的 `v-slot` 来定义我们提供的插槽 prop 的名字：
 
 ```html
 <todo-list>


### PR DESCRIPTION
## Description of Problem
./src/guide/component-slots.md 
line 277
原来写的是：
绑定在 `<slot` > 元素上的 attribute 被称为插槽 prop。
## Proposed Solution
改成了
绑定在 `<slot>` 元素上的 attribute 被称为插槽 prop。
## Additional Information
无
