### PR TITLE
docs: fix the link to CSS Modules in directives

### DIFF
--- a/src/api/directives.md
+++ b/src/api/directives.md
@@ -30,7 +30,7 @@
   在网站上动态渲染任意 HTML 是非常危险的，因为容易导致 [XSS 攻击](https://en.wikipedia.org/wiki/Cross-site_scripting)。只在可信内容上使用 `v-html`，**永不**用在用户提交的内容上。
   :::
 
-  在[单文件组件](../guide/single-file-component.html)里，`scoped` 的样式不会应用在 `v-html` 内部，因为那部分 HTML 没有被 Vue 的模板编译器处理。如果你希望针对 `v-html` 的内容设置带作用域的 CSS，你可以替换为 [CSS modules](https://vue-loader.vuejs.org/en/features/css-modules.html) 或用一个额外的全局 `<style>` 元素手动设置类似 BEM 的作用域策略。
+  在[单文件组件](../guide/single-file-component.html)里，`scoped` 的样式不会应用在 `v-html` 内部，因为那部分 HTML 没有被 Vue 的模板编译器处理。如果你希望针对 `v-html` 的内容设置带作用域的 CSS，你可以替换为 [CSS modules](https://vue-loader.vuejs.org/zh/guide/css-modules.html) 或用一个额外的全局 `<style>` 元素手动设置类似 BEM 的作用域策略。
 
 - **示例**：
 


### PR DESCRIPTION
## Description of Problem
修复v-html 中 CSS Modules 的链接为中文，与useCssModule处 CSS Modules 的链接保持一致
## Proposed Solution

## Additional Information
