### PR TITLE
docs: fix unwrap translate

### DIFF
--- a/src/api/options-composition.md
+++ b/src/api/options-composition.md
@@ -221,7 +221,7 @@
   </script>
   ```
 
-  请注意，从 `setup` 返回的 [refs](refs-api.html#ref) 在模板中访问时会自动展开，因此模板中不需要 `.value`。
+  请注意，从 `setup` 返回的 [refs](refs-api.html#ref) 在模板中访问时会自动解包，因此模板中不需要 `.value`。
 
 - **渲染函数/JSX 的方法**
 

--- a/src/guide/composition-api-setup.md
+++ b/src/guide/composition-api-setup.md
@@ -92,7 +92,7 @@ export default {
 }
 ```
 
-`attrs` 和 `slots` 是有状态的对象，它们总是会随组件本身的更新而更新。这意味着你应该避免对它们进行解构，并始终以 `attrs.x` 或 `slots.x` 的方式引用 property。请注意，与 `props` 不同，`attrs` 和 ` slots` 是**非**响应式的。如果你打算根据 `attrs` 或 `slots` 更改应用副作用，那么应该在 `onUpdated` 生命周期钩子中执行此操作。
+`attrs` 和 `slots` 是有状态的对象，它们总是会随组件本身的更新而更新。这意味着你应该避免对它们进行解构，并始终以 `attrs.x` 或 `slots.x` 的方式引用 property。请注意，与 `props` 不同，`attrs` 和 `slots` 是**非**响应式的。如果你打算根据 `attrs` 或 `slots` 更改应用副作用，那么应该在 `onUpdated` 生命周期钩子中执行此操作。
 
 ## 访问组件的 property
 
@@ -137,7 +137,7 @@ export default {
 </script>
 ```
 
-注意，从 `setup` 返回的 [refs](../api/refs-api.html#ref) 在模板中访问时是[被自动浅解包](/guide/reactivity-fundamentals.html#ref-展开)的，因此不应在模板中使用 `.value`。
+注意，从 `setup` 返回的 [refs](../api/refs-api.html#ref) 在模板中访问时是[被自动浅解包](/guide/reactivity-fundamentals.html#ref-解包)的，因此不应在模板中使用 `.value`。
 
 ## 使用渲染函数
 

--- a/src/guide/reactivity-fundamentals.md
+++ b/src/guide/reactivity-fundamentals.md
@@ -43,9 +43,9 @@ count.value++
 console.log(count.value) // 1
 ```
 
-### Ref 展开
+### Ref 解包
 
-当 ref 作为渲染上下文 (从 [setup()](composition-api-setup.html) 中返回的对象) 上的 property 返回并可以在模板中被访问时，它将自动浅层次展开内部值。只有访问嵌套的 ref 时需要在模板中添加 `.value`：
+当 ref 作为渲染上下文 (从 [setup()](composition-api-setup.html) 中返回的对象) 上的 property 返回并可以在模板中被访问时，它将自动浅层次解包内部值。只有访问嵌套的 ref 时需要在模板中添加 `.value`：
 
 ```vue-html
 <template>
@@ -85,7 +85,7 @@ nested: reactive({
 
 ### 访问响应式对象
 
-当 `ref` 作为响应式对象的 property 被访问或更改时，为使其行为类似于普通 property，它会自动展开内部值：
+当 `ref` 作为响应式对象的 property 被访问或更改时，为使其行为类似于普通 property，它会自动解包内部值：
 
 ```js
 const count = ref(0)
@@ -109,7 +109,7 @@ console.log(state.count) // 2
 console.log(count.value) // 1
 ```
 
-Ref 展开仅发生在被响应式 `Object` 嵌套的时候。当从 `Array` 或原生集合类型如 [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)访问 ref 时，不会进行展开：
+Ref 解包仅发生在被响应式 `Object` 嵌套的时候。当从 `Array` 或原生集合类型如 [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)访问 ref 时，不会进行解包：
 
 ```js
 const books = reactive([ref('Vue 3 Guide')])


### PR DESCRIPTION
#487 看到该 issue 同步的结论，全局搜索文档中的`解构`，觉得翻译合理，无需再修改。

全局搜索官方文档中的 `unwrap` ，逐个修正未翻译为 `解包` 的部分。
