### PR TITLE
docs: fix application-api.md

### DIFF
--- a/src/api/application-api.md
+++ b/src/api/application-api.md
@@ -41,7 +41,7 @@ app.component('my-component', {
 })
 
 // 检索注册的组件(始终返回构造函数)
-const MyComponent = app.component('my-component', {})
+const MyComponent = app.component('my-component')
 ```
 
 - **参考：**[组件基础](../guide/component-basics.html)


### PR DESCRIPTION
如果不传入 definition 参数 (第二个 component 参数)，返回组件定义。

```ts
export declare interface App<HostElement = any> {
    // ...
    component(name: string): Component | undefined;
    component(name: string, component: Component): this;
    // ...
}
```