### PR TITLE
fix: remove incorrect word

### DIFF
--- a/src/guide/component-custom-events.md
+++ b/src/guide/component-custom-events.md
@@ -20,7 +20,7 @@ this.$emit('myEvent')
 
 <VideoLesson href="https://vueschool.io/lessons/defining-custom-events-emits?friend=vuejs" title="Learn how to define which events a component can emit with Vue School">在 Vue School 上观看定义自定义事件的免费视频。</VideoLesson>
 
-可以通过 `emits` 选项在组件上定义已发出的事件。
+可以通过 `emits` 选项在组件上定义发出的事件。
 
 ```js
 app.component('custom-form', {


### PR DESCRIPTION
## Description of Problem
子组件中，`emits` 选项为在组件上定义”发出“的事件，而非”已发出“的事件，此处的形容词”已“容易带来歧义。同时，本文其他地方也均采用的是”发出“而非”已发出“。

## Proposed Solution
建议替换”已发出“为”发出“

## Additional Information
