### PR TITLE
去除component-basics文档中“应该可以”的表述

### DIFF
--- a/src/guide/component-basics.md
+++ b/src/guide/component-basics.md
@@ -316,7 +316,7 @@ app.component('custom-input', {
 })
 ```
 
-现在 `v-model` 就应该可以在这个组件上完美地工作起来了：
+现在 `v-model` 就可以在这个组件上完美地工作起来了：
 
 ```html
 <custom-input v-model="searchText"></custom-input>


### PR DESCRIPTION
去除模糊不清的`应该可以`的表述，可能会导致读者迷惑。

虽然我查阅了英文版本的描述`Now v-model should work perfectly with this component:`，也有should的表述。
如果是确定无疑的事情，我认为是可以删除的，否则最好能给出特例解释。