### PR TITLE
Polish up translation to avoid ambiguity

### DIFF
--- a/src/guide/teleport.md
+++ b/src/guide/teleport.md
@@ -119,7 +119,7 @@ app.component('child-component', {
 
 在这种情况下，即使在不同的地方渲染 `child-component`，它仍将是 `parent-component` 的子级，并将从中接收 `name` prop。
 
-这也意味着来自父组件的注入按预期工作，并且子组件将嵌套在 Vue Devtools 中的父组件之下，而不是放在实际内容移动到的位置。
+这也意味着来自父组件的注入会正常工作，在 Vue Devtools 中你会看到子组件嵌套在父组件之下，而不是出现在他会被实际移动到的位置。
 
 ## 在同一目标上使用多个 teleport
 


### PR DESCRIPTION
读文档的时候感觉这个地方不通顺，可以更信雅达
原文：This also means that injections from a parent component work as expected, and that the child component will be nested below the parent component in the Vue Devtools, instead of being placed where the actual content moved to.