### PR TITLE
Update directives.md:"修改 v-on Vue 2.x 参数遗留"

### DIFF
--- a/src/api/directives.md
+++ b/src/api/directives.md
@@ -207,7 +207,7 @@
   <button @click.prevent="doThis"></button>
 
   <!-- 阻止默认行为，没有表达式 -->
-  <form @submit.prevent></form>
+  <form @click.prevent></form>
 
   <!-- 串联修饰符 -->
   <button @click.stop.prevent="doThis"></button>


### PR DESCRIPTION
## Description of Problem
在新的 Vue 3.0 文档中，模板指令 ```v-on:event``` 修饰符已经被移除，而在 https://v3.cn.vuejs.org/api/directives.html#v-memo 中的 v-on API 示例中还存在 Vue 2.x 的 ```v-on:event``` 参数遗留：[```<form @submit.prevent></form>```] 

## Proposed Solution
因此为遵循 Vue 3.0 模板指令的更改应改为 ```<form @click.prevent></form>```
