### PR TITLE
Update directives.md:"增加 Vue 3.0 v-bind 缺少的参数"

### DIFF
--- a/src/api/directives.md
+++ b/src/api/directives.md
@@ -265,6 +265,9 @@
   <!-- 绑定 attribute -->
   <img v-bind:src="imageSrc" />
 
+  <!-- 绑定 attribute -->
+  <img v-bind:href="hrefTar" />
+
   <!-- 动态 attribute 名 -->
   <button v-bind:[key]="value"></button>
 


### PR DESCRIPTION
增加 Vue 3.0 文档中 https://v3.cn.vuejs.org/api/directives.html#v-bind 缺少的 v-bind:href 参数，适用与 Vue 2.x 和 Vue 3.x。但在官方文档中缺少则会让读者感觉 Vue 2.0 中移除了此参数。

