### PR TITLE
Use npmmirror.com instead of npm.taobao.org

### DIFF
--- a/src/guide/installation.md
+++ b/src/guide/installation.md
@@ -183,4 +183,4 @@ Vue.createApp({
 当使用 `vue-loader` 时，`*.vue` 文件中的模板会在构建时预编译为 JavaScript，在最终的捆绑包中并不需要编译器，因此可以只使用运行时构建版本。
 
 <small>**译者注**  
-<a id="footnote-1"></a>[1] 对于中国大陆用户，建议将 NPM 源设置为[国内的镜像](https://npm.taobao.org/)，可以大幅提升安装速度。</small>
+<a id="footnote-1"></a>[1] 对于中国大陆用户，建议将 NPM 源设置为[国内的镜像](https://npmmirror.com/)，可以大幅提升安装速度。</small>


### PR DESCRIPTION
## Description of Problem
npm.taobao.org 域名已经更新为 npmmirror.com

See https://zhuanlan.zhihu.com/p/430580607

## Proposed Solution

## Additional Information
