### PR TITLE
Update the translation of `where it's injected`

### DIFF
--- a/src/guide/reactivity-fundamentals.md
+++ b/src/guide/reactivity-fundamentals.md
@@ -164,7 +164,7 @@ console.log(book.title) // 'Vue 3 Detailed Guide'
 
 ## 使用 `readonly` 防止更改响应式对象
 
-有时我们想跟踪响应式对象 (`ref` 或 `reactive`) 的变化，但我们也希望防止在应用程序的某个位置更改它。例如，当我们有一个被 [provide](component-provide-inject.html) 的响应式对象时，我们不想让它在注入的时候被改变。为此，我们可以基于原始对象创建一个只读的 proxy 对象：
+有时我们想跟踪响应式对象 (`ref` 或 `reactive`) 的变化，但我们也希望防止在应用程序的某个位置更改它。例如，当我们有一个被 [provide](component-provide-inject.html) 的响应式对象时，我们不想让它在注入之后被改变。为此，我们可以基于原始对象创建一个只读的 proxy 对象：
 
 ```js
 import { reactive, readonly } from 'vue'


### PR DESCRIPTION
## Description of Problem

原文 `when we have a provided reactive object, we want to prevent mutating it where it's injected.` 的意思，应该是说一个 `provide` 响应式对象在被 `inject` 到子组件之后，不希望这个响应式对象被子组件改变（单向数据流思想）。


## Proposed Solution

原翻译 `我们不想让它在注入的时候被改变` 感觉对应的是 `we want to prevent mutating it where it's injecting`。所以**注入的时候**应该不会被改变，而是注入之后被子组件某个操作改变。更改为 `我们不想让它在注入之后被改变` 更合理


## Additional Information

个人愚见，如有误解望各位雅正。