### PR TITLE
Update watch.md

### DIFF
--- a/src/guide/migration/watch.md
+++ b/src/guide/migration/watch.md
@@ -12,7 +12,8 @@ badges:
 
 ## 3.x 语法
 
-当使用 [`watch` 选项](/api/options-data.html#watch)侦听数组时，只有在数组被替换时才会触发回调。换句话说，在数组被改变时侦听回调将不再被触发。要想在数组被改变时触发侦听回调，必须指定 `deep` 选项。
+当使用 [`watch` 选项](/api/options-data.html#watch)侦听ref数组时，只有在数组被替换时才会触发回调。换句话说，在数组被改变时侦听回调将不再被触发。要想在数组被改变时触发侦听回调，必须指定 `deep` 选项。
+当使用 [`watch` 选项](/api/options-data.html#watch)侦听reactive数据时，deep会强制设为true。
 
 ```js
 watch: {


### PR DESCRIPTION
分别测试watch数据源为：ref和reactive定义的简单数组例如 [1,2,3]，经过push操作后，观测的reactive数组可以监听到变化，观测的ref数组未监听到变化。查看源码后发现watch函数对于不同的数据源做了对应处理，所以对检测数组这一块文档提出细微调整。也希望官方文档对watch的更多细节进行描述。

## Description of Problem

## Proposed Solution

## Additional Information
